### PR TITLE
update version to 1.8.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'idea'
 apply plugin: 'project-report'
 
 group = 'com.kenshoo.gradle.plugins'
-version = '1.8.0'
+version = '1.8.3'
 
 task('wrapper', type: Wrapper).configure {
     gradleVersion = '1.7'


### PR DESCRIPTION
Update version to 1.8.3. Next step would be to update kenshoo/search to use this version. And all this is in order to get version 1.0.8 of the liquibase-groovy-dsl plugin.
@AvihayTsayeg @liorhar 
